### PR TITLE
Refactor: Clean up scripts and Go utilities

### DIFF
--- a/build-custom-images.sh
+++ b/build-custom-images.sh
@@ -142,14 +142,18 @@ if [[ $# -eq 0 ]]; then
         if [[ -d "$project_dir" && ( -f "$project_dir/Dockerfile" || -f "$project_dir/docker/Dockerfile" ) ]]; then
             project_name=$(basename "$project_dir")
             
-            # Try to map project to package name
+            # Map project name to package name for specific known projects,
+            # otherwise, attempt to build with an empty package name.
             case "$project_name" in
+                # The "dhis2" project corresponds to the "dhis2-instance" package.
                 "dhis2")
                     build_custom_image "$project_name" "dhis2-instance"
                     ;;
+                # The "sftp" project corresponds to the "sftp-storage" package.
                 "sftp")
                     build_custom_image "$project_name" "sftp-storage"
                     ;;
+                # The "openfn-workflows" project corresponds to the "openfn" package.
                 "openfn-workflows")
                     build_custom_image "$project_name" "openfn"
                     ;;
@@ -162,13 +166,18 @@ if [[ $# -eq 0 ]]; then
 else
     # Build specific projects
     for project_name in "$@"; do
+        # Map project name to package name for specific known projects,
+        # otherwise, attempt to build with an empty package name.
         case "$project_name" in
+            # The "dhis2" project corresponds to the "dhis2-instance" package.
             "dhis2")
                 build_custom_image "$project_name" "dhis2-instance"
                 ;;
+            # The "sftp" project corresponds to the "sftp-storage" package.
             "sftp")
                 build_custom_image "$project_name" "sftp-storage"
                 ;;
+            # The "openfn-workflows" project corresponds to the "openfn" package.
             "openfn-workflows")
                 build_custom_image "$project_name" "openfn"
                 ;;

--- a/scripts/cmd/override-configs/main.go
+++ b/scripts/cmd/override-configs/main.go
@@ -14,6 +14,17 @@ import (
 // STRUCTS
 //
 
+// PackageMetadata defines the structure of the package-metadata.json file.
+// It includes identifier, descriptive information, version, dependencies,
+// environment variables, and override configurations for the package.
+// - Id: A unique identifier for the package.
+// - Name: The human-readable name of the package.
+// - Description: A brief description of the package's purpose.
+// - Type: The type of package (e.g., "platform", "implementation").
+// - Version: The version number of the package.
+// - Dependencies: A list of package IDs that this package depends on.
+// - EnvironmentVariables: A map of environment variables required by the package.
+// - Overrides: A list of file path patterns to be overridden from an implementation package.
 type PackageMetadata struct {
 	Id                   string
 	Name                 string
@@ -25,6 +36,10 @@ type PackageMetadata struct {
 	Overrides            []string
 }
 
+// PlatformPackage encapsulates a package's metadata along with the path
+// to its package-metadata.json file.
+// - Path: The file system path to the package-metadata.json file.
+// - PackageMetadata: The parsed content of the package-metadata.json file.
 type PlatformPackage struct {
 	Path            string
 	PackageMetadata PackageMetadata
@@ -34,12 +49,14 @@ type PlatformPackage struct {
 // HELPERS
 //
 
-func check(e error) {
-	if e != nil {
-		panic(e)
-	}
+// handleError is a helper function to check for errors.
+// If an error is present, it returns the error.
+func handleError(e error) error {
+	return e
 }
 
+// copy copies a file from srcFile to dstFile.
+// It creates the destination file, overwriting it if it already exists.
 func copy(srcFile, dstFile string) error {
 	out, err := os.Create(dstFile)
 	if err != nil {
@@ -69,26 +86,49 @@ func copy(srcFile, dstFile string) error {
 // MAIN
 //
 
-func getAllPackages(platformPath string) []PlatformPackage {
+// getAllPackages scans the specified directory (`platformPath`) recursively
+// to find all files named "package-metadata.json". It then parses each of these
+// files into a PackageMetadata struct and returns a slice of PlatformPackage
+// structs, each containing the path to the metadata file and its parsed content.
+// If any error occurs during directory traversal or file processing, it returns an error.
+func getAllPackages(platformPath string) ([]PlatformPackage, error) {
 	var packages []PlatformPackage
-	filepath.WalkDir(platformPath, func(p string, info os.DirEntry, err error) error {
-		if err != nil {
-			return err
+	err := filepath.WalkDir(platformPath, func(p string, info os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("error walking directory at %s: %w", p, walkErr)
 		}
 		if filepath.Base(p) == "package-metadata.json" {
-			packageMetadata, err := ioutil.ReadFile(p)
-			check(err)
+			packageMetadataBytes, err := ioutil.ReadFile(p)
+			if err != nil {
+				return fmt.Errorf("failed to read file %s: %w", p, err)
+			}
 
 			var packageMetadataJson PackageMetadata
-			json.Unmarshal(packageMetadata, &packageMetadataJson)
+			err = json.Unmarshal(packageMetadataBytes, &packageMetadataJson)
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal package metadata from %s: %w", p, err)
+			}
 			packages = append(packages, PlatformPackage{Path: p, PackageMetadata: packageMetadataJson})
 		}
 		return nil
 	})
-	return packages
+	if err != nil {
+		return nil, err
+	}
+	return packages, nil
 }
 
-func overridePackages(platformDir string, platformPackages, implementationPackages []PlatformPackage) {
+// overridePackages processes a list of implementation packages and applies their overrides
+// to the corresponding platform packages. For each implementation package, it iterates
+// through its files. If a file path matches an override pattern specified in the
+// implementation package's metadata (or if no overrides are specified, all files are
+// considered for override), it copies that file to the corresponding location in the
+// platform directory, effectively overriding the platform's version of the file.
+// - platformDir: The root directory of the platform packages.
+// - platformPackages: A slice of currently known platform packages (not directly used in current logic but available).
+// - implementationPackages: A slice of implementation packages whose files will override those in the platform.
+// It returns an error if any file operation (like creating directories or copying files) fails.
+func overridePackages(platformDir string, platformPackages, implementationPackages []PlatformPackage) error {
 
 	for _, implementationPackage := range implementationPackages {
 
@@ -97,7 +137,9 @@ func overridePackages(platformDir string, platformPackages, implementationPackag
 		overridePackageRoot := filepath.Join(platformDir, packageFolderName)
 
 		err := os.MkdirAll(overridePackageRoot, 0755)
-		check(err)
+		if err = handleError(err); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", overridePackageRoot, err)
+		}
 
 		var implementationPackageOverrides []string
 		if implementationPackage.PackageMetadata.Overrides != nil {
@@ -109,20 +151,25 @@ func overridePackages(platformDir string, platformPackages, implementationPackag
 				return err
 			}
 			relativePackageFilePath, err := filepath.Rel(implementationPackagePath, path)
-			check(err)
+			if err = handleError(err); err != nil {
+				return fmt.Errorf("failed to get relative path for %s: %w", path, err)
+			}
 
 			if info.IsDir() {
 				if relativePackageFilePath != "." {
 					overrideDir := filepath.Join(overridePackageRoot, relativePackageFilePath)
 					if _, err := os.Stat(overrideDir); os.IsNotExist(err) {
 						err = os.Mkdir(overrideDir, 0755)
-						check(err)
+						if err = handleError(err); err != nil {
+							return fmt.Errorf("failed to create directory %s: %w", overrideDir, err)
+						}
 					}
 				}
 			} else {
 				shouldOverride := implementationPackageOverrides == nil
 
 				for _, override := range implementationPackageOverrides {
+					// We ignore regexp.MatchString error as a pattern error is a developer error
 					match, _ := regexp.MatchString(override, relativePackageFilePath)
 					if match {
 						shouldOverride = true
@@ -131,22 +178,51 @@ func overridePackages(platformDir string, platformPackages, implementationPackag
 				}
 				if shouldOverride {
 					err = copy(path, filepath.Join(overridePackageRoot, relativePackageFilePath))
-					check(err)
+					if err = handleError(err); err != nil {
+						return fmt.Errorf("failed to copy file from %s to %s: %w", path, filepath.Join(overridePackageRoot, relativePackageFilePath), err)
+					}
 				}
 			}
 
 			return nil
 		})
+		if err != nil {
+			return err // Propagate error from WalkDir
+		}
 	}
+	return nil
 }
 
+// main is the entry point of the override-configs program.
+// It performs the following steps:
+// 1. Defines the paths for the platform (current directory) and implementation packages ("/implementation").
+// 2. Calls getAllPackages to find and parse all package-metadata.json files for both platform and implementation.
+//    If an error occurs during this stage, it prints the error to stderr and exits.
+// 3. Calls overridePackages to copy files from implementation packages to the platform packages
+//    based on the "Overrides" configuration in their respective package-metadata.json files.
+//    If an error occurs during this stage, it prints the error to stderr and exits.
+// 4. If all operations are successful, it prints a success message.
 func main() {
 	fmt.Println("Overriding configs...")
 	platformPath := "./"
 	implementationPath := "/implementation"
 
-	platformPackages := getAllPackages(platformPath)
-	implementationPackages := getAllPackages(implementationPath)
+	platformPackages, err := getAllPackages(platformPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting platform packages: %v\n", err)
+		os.Exit(1)
+	}
 
-	overridePackages(platformPath, platformPackages, implementationPackages)
+	implementationPackages, err := getAllPackages(implementationPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting implementation packages: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = overridePackages(platformPath, platformPackages, implementationPackages)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error overriding packages: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Configs overridden successfully.")
 }


### PR DESCRIPTION
This commit includes several refactoring improvements to shell scripts and a Go utility program:

1.  **`build-custom-images.sh`**:
    *   Added detailed comments to the `case` statements that map project names to package names. This enhances the readability and maintainability of the script by making the logic for image building clearer.

2.  **`projects/indicator_workflow_testing/test-sftp-integration.sh`**:
    *   Replaced a fixed `sleep 10` with a robust wait loop that actively checks for SFTP server readiness before proceeding. This makes the test script more reliable, especially in environments where services may take variable times to start.
    *   The SFTP connection test command was slightly simplified and now correctly uses the `$SFTP_PORT` variable.

3.  **`scripts/cmd/override-configs/main.go`**:
    *   Improved error handling by changing the `check()` function (which used `panic`) to a system where errors are returned and handled in the `main` function. This makes the program more robust by allowing graceful error reporting and exit.
    *   Added comprehensive comments to data structures (`PackageMetadata`, `PlatformPackage`) and key functions (`getAllPackages`, `overridePackages`, `copy`, `main`) to improve code understanding and maintainability.

These changes aim to improve the overall quality, robustness, and maintainability of the codebase.