### PR TITLE
feat: Bring back MOH CSV file type configurations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+OPENFN_DATABASE_URL=postgresql://openfn:instant101@postgres-1:5432/lightning_dev
 OPENFN_DISABLE_DB_SSL=true
 OPENFN_IS_RESETTABLE_DEMO=true
 OPENFN_LISTEN_ADDRESS=0.0.0.0

--- a/.github/workflows/ci-environment.yml
+++ b/.github/workflows/ci-environment.yml
@@ -148,33 +148,33 @@ jobs:
           
       - name: Deploy PostgreSQL
         run: |
-          ./instant package init -n database-postgres -d
-          
+          ./instant package init -n database-postgres -d --env-file .env.example
+
           # Wait for PostgreSQL to be ready
           echo "Waiting for PostgreSQL..."
           timeout 120s bash -c 'until docker service ls | grep -q "postgres_postgres-1.*1/1"; do sleep 5; done'
           sleep 10
-          
+
       - name: Deploy SFTP Storage
         run: |
-          ./instant package init -n sftp-storage -d
-          
+          ./instant package init -n sftp-storage -d --env-file .env.example
+
           # Wait for SFTP to be ready
           echo "Waiting for SFTP server..."
           timeout 60s bash -c 'until docker service ls | grep -q "sftp-storage_sftp-server.*1/1"; do sleep 5; done'
-          
+
       - name: Deploy DHIS2
         run: |
-          ./instant package init -n dhis2-instance -d
-          
-          # Wait for DHIS2 to be ready 
+          ./instant package init -n dhis2-instance -d --env-file .env.example
+
+          # Wait for DHIS2 to be ready
           echo "Waiting for DHIS2..."
           timeout 300s bash -c 'until docker service ls | grep -q "dhis2_dhis2.*1/1"; do sleep 10; done'
-          
+
       - name: Deploy OpenFN
         run: |
-          ./instant package init -n openfn -d
-          
+          ./instant package init -n openfn -d --env-file .env.example
+
           # Wait for OpenFN to be ready
           echo "Waiting for OpenFN..."
           timeout 120s bash -c 'until docker service ls | grep -q "openfn_openfn.*1/1"; do sleep 5; done'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ cd projects/indicator_workflow_testing && ./run-tests.sh
 
 FILE_TYPE_CONFIGS location: `projects/openfn-workflows/workflows/upload-indicator-files-to-dhis2/jobs/00-scan-sftp-for-changes.js`
 
-### Currently Configured (8 types)
+### Currently Configured (12 types)
 
 | Config Key | Source | Pattern | Format |
 |------------|--------|---------|--------|
@@ -98,16 +98,18 @@ FILE_TYPE_CONFIGS location: `projects/openfn-workflows/workflows/upload-indicato
 | art_data_long_format | MOH/ART | ART_data_long*.xlsx | XLSX |
 | dq_sites | MOH/DQ | *Q*FY*DQ*sites*.xlsx | XLSX |
 | moh_direct_queries | MOH | *Direct*Queries*.xlsx | XLSX |
+| moh_cohort_report_csv | MOH | MoH_CohortReport*.csv | CSV |
+| moh_regimen_distribution_csv | MOH | MoH_RegimenDistributionByWeight*.csv | CSV |
+| moh_survival_analysis_csv | MOH | MoH_SurvivalAnalysis*.csv | CSV |
+| moh_tpt_initiations_csv | MOH | MoH_TPTNewInitiations*.csv | CSV |
 
-### Pending MOH CSV Configs (6 types)
+### MOH CSV Sample Files
 
 Sample files in `projects/sftp/data/samples/moh/`:
-- MoH_CohortReport_*.csv
-- MoH_RegimenDistributionByWeight_*.csv
-- MoH_SurvivalAnalysisGeneral_*.csv
-- MoH_SurvivalAnalysisWomen_*.csv
-- MoH_SurvivalAnalysisChildren_*.csv
-- MoH_TPTNewInitiations_*.csv
+- MoH_CohortReport_*.csv - Quarterly cohort reports with registration indicators
+- MoH_RegimenDistributionByWeight_*.csv - Regimen distribution by gender/age/weight
+- MoH_SurvivalAnalysis*.csv - Survival analysis (General, Women, Children variants)
+- MoH_TPTNewInitiations_*.csv - TB Preventive Therapy initiations
 
 Filename convention: `MoH_{ReportType}_{YEAR}_{QUARTER}_{VERSION}_{TIMESTAMP}.csv`
 

--- a/projects/indicator_workflow_testing/tests/cli/test-simple-sftp-job.sh
+++ b/projects/indicator_workflow_testing/tests/cli/test-simple-sftp-job.sh
@@ -28,6 +28,7 @@ echo ""
 # Run the job directly using CLI with state file containing credentials
 echo "🚀 Running simple SFTP job with unified state file..."
 docker run --rm -i \
+    --network openfn_public \
     -v "$(pwd)/../../../openfn-workflows/workflows/sftp-test/state:/state" \
     -v "$(pwd)/outputs:/outputs" \
     "$DOCKER_IMAGE" /bin/sh <<EOF

--- a/projects/openfn-workflows/workflows/sftp-test/state/sftp-test-state.json
+++ b/projects/openfn-workflows/workflows/sftp-test/state/sftp-test-state.json
@@ -1,0 +1,9 @@
+{
+  "configuration": {
+    "host": "sftp-storage_sftp-server",
+    "port": 22,
+    "username": "openfn",
+    "password": "instant101"
+  },
+  "data": {}
+}

--- a/projects/openfn-workflows/workflows/upload-indicator-files-to-dhis2/configs/file-type-definitions.json
+++ b/projects/openfn-workflows/workflows/upload-indicator-files-to-dhis2/configs/file-type-definitions.json
@@ -1225,5 +1225,314 @@
         }
       ]
     }
+  },
+  "moh_cohort_report_csv": {
+    "fileType": "csv",
+    "displayName": "MoH Cohort Report CSV",
+    "description": "MoH quarterly cohort report with registration and initiation indicators",
+    "filePrefix": "MoH_CohortReport",
+    "columnMappings": {
+      "facility": {
+        "sourceColumns": ["Facility Name", "facility", "Facility"],
+        "targetField": "orgUnit",
+        "required": true
+      },
+      "indicator": {
+        "sourceColumns": ["Indicator Name", "indicator", "Indicator"],
+        "targetField": "dataElement",
+        "required": true
+      },
+      "period": {
+        "sourceColumns": ["reporting_period", "Period", "Quarter"],
+        "targetField": "period",
+        "required": true
+      },
+      "value": {
+        "sourceColumns": ["newly_reg_in_quarter", "Value", "value"],
+        "targetField": "value",
+        "required": true,
+        "dataType": "numeric"
+      }
+    },
+    "headerMap": {
+      "Facility Name": "Facility Name",
+      "indicator_number": "indicator_number",
+      "site_id": "site_id",
+      "Indicator Name": "Indicator Name",
+      "newly_reg_in_quarter": "newly_reg_in_quarter",
+      "cumulative_ever_reg": "cumulative_ever_reg",
+      "reporting_period": "reporting_period"
+    },
+    "uniqueValueCollectors": {
+      "sites": { "targetField": "orgUnit" },
+      "indicators": { "targetField": "dataElement" }
+    },
+    "builders": {
+      "dataElements": {
+        "uniqueValueKey": "indicators",
+        "valueType": "NUMBER",
+        "aggregationType": "SUM",
+        "domainType": "AGGREGATE"
+      }
+    },
+    "dhis2Builder": "default",
+    "dhis2Config": {
+      "periodType": "Quarterly",
+      "periodSource": "filename",
+      "openFuturePeriods": 4
+    }
+  },
+  "moh_regimen_distribution_csv": {
+    "fileType": "csv",
+    "displayName": "MoH Regimen Distribution by Weight CSV",
+    "description": "MoH regimen distribution disaggregated by gender, age, weight band, and regimen category",
+    "filePrefix": "MoH_RegimenDistributionByWeight",
+    "columnMappings": {
+      "site_id": {
+        "sourceColumns": ["site_id"],
+        "targetField": "orgUnit",
+        "required": true
+      },
+      "gender": {
+        "sourceColumns": ["gender", "Gender", "sex", "Sex"],
+        "targetField": "categoryOptions.sex",
+        "required": false
+      },
+      "age_group": {
+        "sourceColumns": ["age_group", "Age Group", "Age"],
+        "targetField": "categoryOptions.ageGroup",
+        "required": false
+      },
+      "weight_band": {
+        "sourceColumns": ["weight_band", "Weight Band", "Weight"],
+        "targetField": "categoryOptions.weightBand",
+        "required": false
+      },
+      "regimen_category": {
+        "sourceColumns": ["regimen_category", "Regimen", "Regimen Category"],
+        "targetField": "dataElement",
+        "required": true
+      },
+      "value": {
+        "sourceColumns": ["total_clients", "Total", "Count", "Value"],
+        "targetField": "value",
+        "required": true,
+        "dataType": "numeric"
+      }
+    },
+    "headerMap": {
+      "site_id": "site_id",
+      "gender": "gender",
+      "age_group": "age_group",
+      "weight_band": "weight_band",
+      "regimen_category": "regimen_category",
+      "total_clients": "total_clients"
+    },
+    "uniqueValueCollectors": {
+      "sites": { "targetField": "orgUnit" },
+      "indicators": { "targetField": "dataElement" },
+      "sexValues": { "targetField": "categoryOptions.sex" },
+      "ageGroups": { "targetField": "categoryOptions.ageGroup" },
+      "weightBands": { "targetField": "categoryOptions.weightBand" }
+    },
+    "builders": {
+      "dataElements": {
+        "uniqueValueKey": "indicators",
+        "valueType": "INTEGER",
+        "aggregationType": "SUM",
+        "domainType": "AGGREGATE"
+      },
+      "categories": [
+        { "name": "Sex", "shortName": "Sex", "code": "SEX", "uniqueValueKey": "sexValues" },
+        { "name": "Age Group", "shortName": "Age Group", "code": "AGE_GROUP", "uniqueValueKey": "ageGroups" },
+        { "name": "Weight Band", "shortName": "Weight Band", "code": "WEIGHT_BAND", "uniqueValueKey": "weightBands" }
+      ]
+    },
+    "dhis2Builder": "default",
+    "dhis2Config": {
+      "periodType": "Quarterly",
+      "periodSource": "filename",
+      "openFuturePeriods": 4
+    }
+  },
+  "moh_survival_analysis_csv": {
+    "fileType": "csv",
+    "displayName": "MoH Survival Analysis CSV",
+    "description": "MoH survival analysis report with multiple outcome columns (General, Women, Children)",
+    "filePatterns": ["MoH_SurvivalAnalysis*.csv"],
+    "columnMappings": {
+      "site_id": {
+        "sourceColumns": ["site_id"],
+        "targetField": "orgUnit",
+        "required": true
+      },
+      "year": {
+        "sourceColumns": ["Year"],
+        "targetField": "categoryOptions.year",
+        "required": true
+      },
+      "quarter": {
+        "sourceColumns": ["Quarter"],
+        "targetField": "period",
+        "required": true
+      },
+      "interval": {
+        "sourceColumns": ["Interval"],
+        "targetField": "categoryOptions.interval",
+        "required": false
+      },
+      "total_registered": {
+        "sourceColumns": ["Total Registered"],
+        "targetField": "survival_total_registered",
+        "required": false,
+        "dataType": "numeric"
+      },
+      "total_alive": {
+        "sourceColumns": ["Total Alive"],
+        "targetField": "survival_total_alive",
+        "required": false,
+        "dataType": "numeric"
+      },
+      "patient_died": {
+        "sourceColumns": ["Patient Died"],
+        "targetField": "survival_patient_died",
+        "required": false,
+        "dataType": "numeric"
+      },
+      "total_defaulted": {
+        "sourceColumns": ["Total Defaulted"],
+        "targetField": "survival_total_defaulted",
+        "required": false,
+        "dataType": "numeric"
+      },
+      "treatment_stopped": {
+        "sourceColumns": ["Treatment Stopped"],
+        "targetField": "survival_treatment_stopped",
+        "required": false,
+        "dataType": "numeric"
+      },
+      "transferred_out": {
+        "sourceColumns": ["Patient transferred out"],
+        "targetField": "survival_transferred_out",
+        "required": false,
+        "dataType": "numeric"
+      },
+      "unknown": {
+        "sourceColumns": ["Unknown"],
+        "targetField": "survival_unknown",
+        "required": false,
+        "dataType": "numeric"
+      }
+    },
+    "headerMap": {
+      "site_id": "site_id",
+      "Year": "Year",
+      "Quarter": "Quarter",
+      "Interval": "Interval",
+      "Total Registered": "Total Registered",
+      "Total Alive": "Total Alive",
+      "Patient Died": "Patient Died",
+      "Total Defaulted": "Total Defaulted",
+      "Treatment Stopped": "Treatment Stopped",
+      "Patient transferred out": "Patient transferred out",
+      "Unknown": "Unknown"
+    },
+    "uniqueValueCollectors": {
+      "sites": { "targetField": "orgUnit" },
+      "intervals": { "targetField": "categoryOptions.interval" }
+    },
+    "builders": {
+      "dataElements": {
+        "uniqueValueKey": "indicators",
+        "valueType": "INTEGER",
+        "aggregationType": "SUM",
+        "domainType": "AGGREGATE"
+      }
+    },
+    "dhis2Builder": "default",
+    "dhis2Config": {
+      "periodType": "Quarterly",
+      "periodSource": "data",
+      "openFuturePeriods": 4
+    }
+  },
+  "moh_tpt_initiations_csv": {
+    "fileType": "csv",
+    "displayName": "MoH TPT New Initiations CSV",
+    "description": "MoH TB Preventive Therapy initiations with multiple regimen columns",
+    "filePrefix": "MoH_TPTNewInitiations",
+    "columnMappings": {
+      "site_id": {
+        "sourceColumns": ["site_id"],
+        "targetField": "orgUnit",
+        "required": true
+      },
+      "gender": {
+        "sourceColumns": ["gender", "Gender", "sex", "Sex"],
+        "targetField": "categoryOptions.sex",
+        "required": false
+      },
+      "age_group": {
+        "sourceColumns": ["age_group", "Age Group", "Age"],
+        "targetField": "categoryOptions.ageGroup",
+        "required": false
+      },
+      "tpt_3hp_new": {
+        "sourceColumns": ["3HP (Started New on ART)"],
+        "targetField": "tpt_3hp_new",
+        "required": false,
+        "dataType": "numeric"
+      },
+      "tpt_6h_new": {
+        "sourceColumns": ["6H (Started New on ART)"],
+        "targetField": "tpt_6h_new",
+        "required": false,
+        "dataType": "numeric"
+      },
+      "tpt_3hp_previous": {
+        "sourceColumns": ["3HP (Started Previously on ART)"],
+        "targetField": "tpt_3hp_previous",
+        "required": false,
+        "dataType": "numeric"
+      },
+      "tpt_6h_previous": {
+        "sourceColumns": ["6H (Started Previously on ART)"],
+        "targetField": "tpt_6h_previous",
+        "required": false,
+        "dataType": "numeric"
+      }
+    },
+    "headerMap": {
+      "site_id": "site_id",
+      "gender": "gender",
+      "age_group": "age_group",
+      "3HP (Started New on ART)": "3HP (Started New on ART)",
+      "6H (Started New on ART)": "6H (Started New on ART)",
+      "3HP (Started Previously on ART)": "3HP (Started Previously on ART)",
+      "6H (Started Previously on ART)": "6H (Started Previously on ART)"
+    },
+    "uniqueValueCollectors": {
+      "sites": { "targetField": "orgUnit" },
+      "sexValues": { "targetField": "categoryOptions.sex" },
+      "ageGroups": { "targetField": "categoryOptions.ageGroup" }
+    },
+    "builders": {
+      "dataElements": {
+        "uniqueValueKey": "indicators",
+        "valueType": "INTEGER",
+        "aggregationType": "SUM",
+        "domainType": "AGGREGATE"
+      },
+      "categories": [
+        { "name": "Sex", "shortName": "Sex", "code": "SEX", "uniqueValueKey": "sexValues" },
+        { "name": "Age Group", "shortName": "Age Group", "code": "AGE_GROUP", "uniqueValueKey": "ageGroups" }
+      ]
+    },
+    "dhis2Builder": "default",
+    "dhis2Config": {
+      "periodType": "Quarterly",
+      "periodSource": "filename",
+      "openFuturePeriods": 4
+    }
   }
 }

--- a/projects/openfn-workflows/workflows/upload-indicator-files-to-dhis2/jobs/00-scan-sftp-for-changes.js
+++ b/projects/openfn-workflows/workflows/upload-indicator-files-to-dhis2/jobs/00-scan-sftp-for-changes.js
@@ -677,6 +677,320 @@ const FILE_TYPE_CONFIGS = {
         }
       ]
     }
+  },
+  // ============================================
+  // MOH CSV File Types
+  // ============================================
+  moh_cohort_report_csv: {
+    fileType: 'csv',
+    displayName: 'MoH Cohort Report CSV',
+    description: 'MoH quarterly cohort report with registration and initiation indicators',
+    filePrefix: 'MoH_CohortReport',
+    columnMappings: {
+      facility: {
+        sourceColumns: ['Facility Name', 'facility', 'Facility'],
+        targetField: 'orgUnit',
+        required: true
+      },
+      indicator: {
+        sourceColumns: ['Indicator Name', 'indicator', 'Indicator'],
+        targetField: 'dataElement',
+        required: true
+      },
+      period: {
+        sourceColumns: ['reporting_period', 'Period', 'Quarter'],
+        targetField: 'period',
+        required: true
+      },
+      value: {
+        sourceColumns: ['newly_reg_in_quarter', 'Value', 'value'],
+        targetField: 'value',
+        required: true,
+        dataType: 'numeric'
+      }
+    },
+    headerMap: {
+      'Facility Name': 'Facility Name',
+      'indicator_number': 'indicator_number',
+      'site_id': 'site_id',
+      'Indicator Name': 'Indicator Name',
+      'newly_reg_in_quarter': 'newly_reg_in_quarter',
+      'cumulative_ever_reg': 'cumulative_ever_reg',
+      'reporting_period': 'reporting_period'
+    },
+    uniqueValueCollectors: {
+      sites: { targetField: 'orgUnit' },
+      indicators: { targetField: 'dataElement' }
+    },
+    builders: {
+      dataElements: {
+        uniqueValueKey: 'indicators',
+        valueType: 'NUMBER',
+        aggregationType: 'SUM',
+        domainType: 'AGGREGATE'
+      }
+    },
+    dhis2Builder: 'default',
+    dhis2Config: {
+      periodType: 'Quarterly',
+      periodSource: 'filename',
+      openFuturePeriods: 4
+    }
+  },
+  moh_regimen_distribution_csv: {
+    fileType: 'csv',
+    displayName: 'MoH Regimen Distribution by Weight CSV',
+    description: 'MoH regimen distribution disaggregated by gender, age, weight band, and regimen category',
+    filePrefix: 'MoH_RegimenDistributionByWeight',
+    columnMappings: {
+      site_id: {
+        sourceColumns: ['site_id'],
+        targetField: 'orgUnit',
+        required: true
+      },
+      gender: {
+        sourceColumns: ['gender', 'Gender', 'sex', 'Sex'],
+        targetField: 'categoryOptions.sex',
+        required: false
+      },
+      age_group: {
+        sourceColumns: ['age_group', 'Age Group', 'Age'],
+        targetField: 'categoryOptions.ageGroup',
+        required: false
+      },
+      weight_band: {
+        sourceColumns: ['weight_band', 'Weight Band', 'Weight'],
+        targetField: 'categoryOptions.weightBand',
+        required: false
+      },
+      regimen_category: {
+        sourceColumns: ['regimen_category', 'Regimen', 'Regimen Category'],
+        targetField: 'dataElement',
+        required: true
+      },
+      value: {
+        sourceColumns: ['total_clients', 'Total', 'Count', 'Value'],
+        targetField: 'value',
+        required: true,
+        dataType: 'numeric'
+      }
+    },
+    headerMap: {
+      'site_id': 'site_id',
+      'gender': 'gender',
+      'age_group': 'age_group',
+      'weight_band': 'weight_band',
+      'regimen_category': 'regimen_category',
+      'total_clients': 'total_clients'
+    },
+    uniqueValueCollectors: {
+      sites: { targetField: 'orgUnit' },
+      indicators: { targetField: 'dataElement' },
+      sexValues: { targetField: 'categoryOptions.sex' },
+      ageGroups: { targetField: 'categoryOptions.ageGroup' },
+      weightBands: { targetField: 'categoryOptions.weightBand' }
+    },
+    builders: {
+      dataElements: {
+        uniqueValueKey: 'indicators',
+        valueType: 'INTEGER',
+        aggregationType: 'SUM',
+        domainType: 'AGGREGATE'
+      },
+      categories: [
+        { name: 'Sex', shortName: 'Sex', code: 'SEX', uniqueValueKey: 'sexValues' },
+        { name: 'Age Group', shortName: 'Age Group', code: 'AGE_GROUP', uniqueValueKey: 'ageGroups' },
+        { name: 'Weight Band', shortName: 'Weight Band', code: 'WEIGHT_BAND', uniqueValueKey: 'weightBands' }
+      ]
+    },
+    dhis2Builder: 'default',
+    dhis2Config: {
+      periodType: 'Quarterly',
+      periodSource: 'filename',
+      openFuturePeriods: 4
+    }
+  },
+  moh_survival_analysis_csv: {
+    fileType: 'csv',
+    displayName: 'MoH Survival Analysis CSV',
+    description: 'MoH survival analysis report with multiple outcome columns (General, Women, Children)',
+    filePatterns: ['MoH_SurvivalAnalysis*.csv'],
+    columnMappings: {
+      site_id: {
+        sourceColumns: ['site_id'],
+        targetField: 'orgUnit',
+        required: true
+      },
+      year: {
+        sourceColumns: ['Year'],
+        targetField: 'categoryOptions.year',
+        required: true
+      },
+      quarter: {
+        sourceColumns: ['Quarter'],
+        targetField: 'period',
+        required: true
+      },
+      interval: {
+        sourceColumns: ['Interval'],
+        targetField: 'categoryOptions.interval',
+        required: false
+      },
+      // Multi-value columns - each becomes a separate dataValue
+      total_registered: {
+        sourceColumns: ['Total Registered'],
+        targetField: 'survival_total_registered',
+        required: false,
+        dataType: 'numeric'
+      },
+      total_alive: {
+        sourceColumns: ['Total Alive'],
+        targetField: 'survival_total_alive',
+        required: false,
+        dataType: 'numeric'
+      },
+      patient_died: {
+        sourceColumns: ['Patient Died'],
+        targetField: 'survival_patient_died',
+        required: false,
+        dataType: 'numeric'
+      },
+      total_defaulted: {
+        sourceColumns: ['Total Defaulted'],
+        targetField: 'survival_total_defaulted',
+        required: false,
+        dataType: 'numeric'
+      },
+      treatment_stopped: {
+        sourceColumns: ['Treatment Stopped'],
+        targetField: 'survival_treatment_stopped',
+        required: false,
+        dataType: 'numeric'
+      },
+      transferred_out: {
+        sourceColumns: ['Patient transferred out'],
+        targetField: 'survival_transferred_out',
+        required: false,
+        dataType: 'numeric'
+      },
+      unknown: {
+        sourceColumns: ['Unknown'],
+        targetField: 'survival_unknown',
+        required: false,
+        dataType: 'numeric'
+      }
+    },
+    headerMap: {
+      'site_id': 'site_id',
+      'Year': 'Year',
+      'Quarter': 'Quarter',
+      'Interval': 'Interval',
+      'Total Registered': 'Total Registered',
+      'Total Alive': 'Total Alive',
+      'Patient Died': 'Patient Died',
+      'Total Defaulted': 'Total Defaulted',
+      'Treatment Stopped': 'Treatment Stopped',
+      'Patient transferred out': 'Patient transferred out',
+      'Unknown': 'Unknown'
+    },
+    uniqueValueCollectors: {
+      sites: { targetField: 'orgUnit' },
+      intervals: { targetField: 'categoryOptions.interval' }
+    },
+    builders: {
+      dataElements: {
+        uniqueValueKey: 'indicators',
+        valueType: 'INTEGER',
+        aggregationType: 'SUM',
+        domainType: 'AGGREGATE'
+      }
+    },
+    dhis2Builder: 'default',
+    dhis2Config: {
+      periodType: 'Quarterly',
+      periodSource: 'data',
+      openFuturePeriods: 4
+    }
+  },
+  moh_tpt_initiations_csv: {
+    fileType: 'csv',
+    displayName: 'MoH TPT New Initiations CSV',
+    description: 'MoH TB Preventive Therapy initiations with multiple regimen columns',
+    filePrefix: 'MoH_TPTNewInitiations',
+    columnMappings: {
+      site_id: {
+        sourceColumns: ['site_id'],
+        targetField: 'orgUnit',
+        required: true
+      },
+      gender: {
+        sourceColumns: ['gender', 'Gender', 'sex', 'Sex'],
+        targetField: 'categoryOptions.sex',
+        required: false
+      },
+      age_group: {
+        sourceColumns: ['age_group', 'Age Group', 'Age'],
+        targetField: 'categoryOptions.ageGroup',
+        required: false
+      },
+      // Multi-value columns - each becomes a separate dataValue
+      tpt_3hp_new: {
+        sourceColumns: ['3HP (Started New on ART)'],
+        targetField: 'tpt_3hp_new',
+        required: false,
+        dataType: 'numeric'
+      },
+      tpt_6h_new: {
+        sourceColumns: ['6H (Started New on ART)'],
+        targetField: 'tpt_6h_new',
+        required: false,
+        dataType: 'numeric'
+      },
+      tpt_3hp_previous: {
+        sourceColumns: ['3HP (Started Previously on ART)'],
+        targetField: 'tpt_3hp_previous',
+        required: false,
+        dataType: 'numeric'
+      },
+      tpt_6h_previous: {
+        sourceColumns: ['6H (Started Previously on ART)'],
+        targetField: 'tpt_6h_previous',
+        required: false,
+        dataType: 'numeric'
+      }
+    },
+    headerMap: {
+      'site_id': 'site_id',
+      'gender': 'gender',
+      'age_group': 'age_group',
+      '3HP (Started New on ART)': '3HP (Started New on ART)',
+      '6H (Started New on ART)': '6H (Started New on ART)',
+      '3HP (Started Previously on ART)': '3HP (Started Previously on ART)',
+      '6H (Started Previously on ART)': '6H (Started Previously on ART)'
+    },
+    uniqueValueCollectors: {
+      sites: { targetField: 'orgUnit' },
+      sexValues: { targetField: 'categoryOptions.sex' },
+      ageGroups: { targetField: 'categoryOptions.ageGroup' }
+    },
+    builders: {
+      dataElements: {
+        uniqueValueKey: 'indicators',
+        valueType: 'INTEGER',
+        aggregationType: 'SUM',
+        domainType: 'AGGREGATE'
+      },
+      categories: [
+        { name: 'Sex', shortName: 'Sex', code: 'SEX', uniqueValueKey: 'sexValues' },
+        { name: 'Age Group', shortName: 'Age Group', code: 'AGE_GROUP', uniqueValueKey: 'ageGroups' }
+      ]
+    },
+    dhis2Builder: 'default',
+    dhis2Config: {
+      periodType: 'Quarterly',
+      periodSource: 'filename',
+      openFuturePeriods: 4
+    }
   }
 };
 


### PR DESCRIPTION
## Summary

Bring in support for 4 MOH CSV file types to enable processing of Ministry of Health indicator data:

- **moh_cohort_report_csv**: Quarterly cohort reports with registration/initiation indicators
- **moh_regimen_distribution_csv**: Regimen distribution disaggregated by gender, age, and weight band
- **moh_survival_analysis_csv**: Survival analysis reports (covers General, Women, Children variants)
- **moh_tpt_initiations_csv**: TB Preventive Therapy (TPT) initiations with multiple regimen columns

## Changes

| File | Description |
|------|-------------|
| `jobs/00-scan-sftp-for-changes.js` | Add 4 MOH CSV configs to FILE_TYPE_CONFIGS |
| `configs/file-type-definitions.json` | Sync external config file |
| `CLAUDE.md` | Update documentation (8 → 12 configured file types) |

## Sample Files

Test data available in `projects/sftp/data/samples/moh/`:
- `MoH_CohortReport_2025_Q1_Initial_v1_20250805160300.csv`
- `MoH_RegimenDistributionByWeight_2025_Q1_Initial_v1_20250805160300.csv`
- `MoH_SurvivalAnalysis{General,Women,Children}_2025_Q1_Initial_v1_20250805160300.csv`
- `MoH_TPTNewInitiations_2025_Q1_Initial_v1_20250805160300.csv`

## Test plan

- [x] JavaScript syntax validation passes (`node --check`)
- [x] JSON syntax validation passes
- [ ] End-to-end workflow test with MOH CSV files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds 4 MoH CSV file type configurations, updates docs, and adjusts CI/test to deploy with env file and run SFTP CLI test on the correct network.
> 
> - **Workflows**:
>   - Add 4 MoH CSV configs in `jobs/00-scan-sftp-for-changes.js` and sync in `configs/file-type-definitions.json` (`moh_cohort_report_csv`, `moh_regimen_distribution_csv`, `moh_survival_analysis_csv`, `moh_tpt_initiations_csv`) with column mappings, headers, builders, and DHIS2 settings.
> - **Docs**:
>   - Update `CLAUDE.md` to reflect 12 configured file types and describe MoH CSV samples.
> - **CI/CD**:
>   - Pass `--env-file .env.example` to `./instant package init` for PostgreSQL, SFTP, DHIS2, and OpenFN in `ci-environment.yml`.
>   - Run simple SFTP CLI test on `openfn_public` network; add state file `workflows/sftp-test/state/sftp-test-state.json` with credentials.
> - **Config**:
>   - Add `OPENFN_DATABASE_URL` to `.env.example`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53a59a500474aa3ffaead3e8005d8e2ca3652a50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->